### PR TITLE
Some cleaning for English language file and fixed German translation.

### DIFF
--- a/raptor/src/raptor/international/L10n.java
+++ b/raptor/src/raptor/international/L10n.java
@@ -30,6 +30,7 @@ public class L10n {
         public static boolean noSavedLocaleFile = false;
 	private static L10n singletonInstance;
 	private static ResourceBundle captions;
+        private static ResourceBundle fallBackCaptions;
         public static Locale[] availableLocales = { Locale.ENGLISH, Locale.ITALIAN, Locale.GERMAN, 
 		new Locale("uk")  };
 	private static Locale suitLocCache;
@@ -50,6 +51,9 @@ public class L10n {
 		currentLocale = locale;
 		captions = ResourceBundle.getBundle("raptor.international.Messages",
 				locale);
+                // load English resources to use when local translation does
+                // not contain a key
+                fallBackCaptions = ResourceBundle.getBundle("raptor.international.Messages", Locale.ENGLISH);
 	}
 	
 	public static String getStringS(String key) {
@@ -57,7 +61,12 @@ public class L10n {
 	}
 	
 	public String getString(String key) {
-		return captions.getString(key);
+                try {
+                    return captions.getString(key);
+                } catch (java.util.MissingResourceException e) {
+                    // use English string if not provided in translation
+                    return fallBackCaptions.getString(key);
+                }
 	}
 	
 	/**

--- a/raptor/src/raptor/international/Messages_de.properties
+++ b/raptor/src/raptor/international/Messages_de.properties
@@ -12,7 +12,6 @@ xMilliseconds={0,number,integer} Millisekunden
 noneSpecified=Nicht angegeben
 white=Wei\u00df
 black=Schwarz
-rated=Gewertet
 mainCont0=Das Schlie\u00dfen der Hauptkonsole trennt die Verbindung zu 
 mainCont1=. Wollen Sie fortsetzen?
 mainCont2=Konsole
@@ -38,7 +37,6 @@ wild4=Wild 4 (Zuf\u00e4llige Figuren mit ungleichfarbigen L\u00e4ufern)
 wild5=Wild 5 (Wei\u00dfe Bauern beginnen auf der 7., wei\u00dfe Figuren auf der 8. Reihe)
 wild8=Wild 8 (Bauern beginnen auf der 4. Reihe)
 wild8a=Wild 8a (Bauern beginnen auf der 5. Reihe)
-	
 FicsSeekDialog.title=Fics Seek Fenster
 FicsSeekDialog.gameType=Spieltyp:
 FicsSeekDialog.minutes=Minuten:
@@ -305,7 +303,8 @@ chessBArP8=Farbe f\u00fcr eigene Pfeile:
 chessBArP9=Farbe f\u00fcr Premove-Pfeile:
 chessBArP10=Farbe f\u00fcr Gegner-Pfeile:
 chessBArP11=Farbe f\u00fcr Beobachter-Pfeile:
-chessEngines=Chess Engines
+chessEngines=Stockfish 7 Einstellungen
+movesToSuggest=Anzahl Varianten:
 connQuadrP1=\tRaptor verwendet ein Quadranten-System f\u00fcr das Layout. Wenn ein Quadrant kein Element enth\u00e4lt, wird er nicht angezeigt und die restlichen Quadranten f\u00fcllen seinen Platz aus. Sie k\u00f6nnen Elemente mit Drag-And-Drop auf die Quadranten verteilen. Doppelklick auf einen Tab maximiert seinen Quadranten. Ein Optionsmenu ist durch einen Rechtsklick erreichbar. 
 connQuadrP2=Hier k\u00f6nnen Sie bestimmen in welchen Quadranten die folgenden Inhalte plaziert werden. 
 connQuadrP3=BughouseButtons:
@@ -746,7 +745,6 @@ gameWI27=Ohne Zeit
 gameWI28=Wild
 gameWI29=analysieren
 gameWI30=Aktualisiert: 
-
 processing=Bearbeite...
 pgnParseWI10=Turnier
 pgnParseWI11=Wei\u00df
@@ -1123,8 +1121,7 @@ err=Error:
 unnToSend=Error: Kann {0} nicht an {1} senden. Keine Verbindung.
 blockTell=Nachricht von {0} blockiert, da er/sie auf der erweiterten Censorliste ist.
 rapPtime=Raptor will not work with ptime set. Command vetoed.
-
-
+soundPack=Sound Pack
 newVersion=Neue Version
 newVersAvail=Raptor {0} ist verf\u00fcgbar. Zum Updaten neustarten. Sie k\u00f6nnen automatische Updates ausschalten in Einstellungen->Allgemeines.
 AnalysisCommentsGenerator_0=a queen

--- a/raptor/src/raptor/international/Messages_en.properties
+++ b/raptor/src/raptor/international/Messages_en.properties
@@ -12,7 +12,6 @@ xMilliseconds={0,number,integer} milliseconds
 noneSpecified=None Specified
 white=White
 black=Black
-rated=Rated
 mainCont0=Closing a main console will disconnect you from 
 mainCont1=. Do you wish to proceed?
 mainCont2=Main
@@ -38,7 +37,6 @@ wild4=Wild 4 (Random pieces balanced bishops)
 wild5=Wild 5 (White pawns start on 7th White pieces on 8th)
 wild8=Wild 8 (Pawns start on 4th rank)
 wild8a=Wild 8a (Pawn start on 5th rank)
-	
 FicsSeekDialog.title=Fics Seek Dialog
 FicsSeekDialog.gameType=Game Type:
 FicsSeekDialog.minutes=Minutes:
@@ -747,7 +745,6 @@ gameWI27=Untimed
 gameWI28=Wild
 gameWI29=examine
 gameWI30=Last refreshed: 
-
 processing=Processing...
 pgnParseWI10=Event
 pgnParseWI11=White
@@ -1124,7 +1121,6 @@ err=Error:
 unnToSend=Error: Unable to send {0} to {1}. There is currently no connection.
 blockTell=Blocked tell sent from {0} because he/she is on extended censor.
 rapPtime=Raptor will not work with ptime set. Command vetoed.
-
 soundPack=Sound Pack
 newVersion=New Version
 newVersAvail=Raptor {0} is available. Restart to upgrade to it. You can turn off updates on the Preferences->General page.


### PR DESCRIPTION
I've removed some empty lines from English and German translation files. (Hope that's fine)

Two keys appeared twice:
rated and uciAnalW_7
I assumed it's save to just delete the second "rated" line, because it's the same value.
uciAnalW_7, however, seems to be a typo the second time. Maybe you can check on that one.

There were also two new keys missing in the German file, which lead to error messages.